### PR TITLE
Update address block, use event key and fix website conditional

### DIFF
--- a/brewery.js
+++ b/brewery.js
@@ -4,7 +4,7 @@ const input = document.getElementById("search-input");
 
 input.addEventListener("keyup", function(e) {
   e.preventDefault();
-  if (e.keyCode === 13) {
+  if (e.key === 'Enter') {
     document.getElementById("search-btn").click();
   }
 });
@@ -76,8 +76,8 @@ var InstantSearch = {
             nodeVal = nodeVal.substring(foundIndex + myToken.length);
           } // Whend
 
-        } // Next i 
-      }; // End Function checkAndReplace 
+        } // Next i
+      }; // End Function checkAndReplace
 
       function iterator(p) {
         if (p === null) return;
@@ -97,21 +97,21 @@ var InstantSearch = {
       }; // End Function iterator
 
       iterator(options[id.container]);
-    } // End Function highlighter    
+    } // End Function highlighter
 
     internalHighlighter({
-      container: container, 
+      container: container,
       all: {
         className: "highlighter"
       },
       tokens: [
         {
-          token: highlightText, 
-          className: "highlight", 
+          token: highlightText,
+          className: "highlight",
           sensitiveSearch: false
         }
       ]
-    }); // End Call internalHighlighter 
+    }); // End Call internalHighlighter
   } // End Function highlight
 };
 
@@ -175,7 +175,7 @@ document.getElementById("search-btn").addEventListener("click", function() {
               `card-topper card-img-top ${response.data[i].brewery_type}`
             );
           }
-          
+
           breweryType.textContent = `${response.data[i].brewery_type}`;
           card.appendChild(breweryType);
 
@@ -188,20 +188,16 @@ document.getElementById("search-btn").addEventListener("click", function() {
           breweryName.textContent = `${response.data[i].name}`;
           cardBody.appendChild(breweryName);
 
-          // some city and state data were coming back null
-          if (
-            `${response.data[i].city}` != "null" ||
-            `${response.data[i].state}` != "null"
-          ) {
-            const breweryAddress = document.createElement("address");
-            breweryAddress.innerHTML = `${response.data[i].street}<br/>${
-              response.data[i].city
-            }, ${response.data[i].state} ${response.data[i].postal_code}`;
-            cardBody.appendChild(breweryAddress);
-          }
+          const breweryAddress = document.createElement("address");
+          const street = response.data[i].street || "";
+          const city = response.data[i].city || "";
+          const state = response.data[i].state || "";
+          const zip = response.data[i].postal_code || "";
+          breweryAddress.innerHTML = `${street}<br/>${city}, ${state} ${zip}`;
+          cardBody.appendChild(breweryAddress);
 
           // not all entries have website URLs
-          if (`${response.data[i].website_url}` != null) {
+          if (response.data[i].website_url != null) {
             const href = document.createElement("a");
             href.setAttribute("href", `${response.data[i].website_url}`);
             href.setAttribute("class", "card-link");
@@ -231,7 +227,7 @@ document.getElementById("search-btn").addEventListener("click", function() {
       .then(function() {
         if(search){
           var results = document.getElementById("resultsArea");
-          InstantSearch.highlight(results, search);                 
+          InstantSearch.highlight(results, search);
         }
       });
   } else {


### PR DESCRIPTION
## Describe what this PR is for
This PR updates the logic for displaying the address information from the breweries response. I noticed the address displayed `null` on a few entries so instead of conditionally displaying the address information, I used variables for the response data and if the response is null it outputs an empty string.

I also updated the if block with the variable (removing the template strings) because I noticed the website link would still be displayed when `null` was returned from the response.

I also updated the event listener for the enter key to use key replacing the deprecated keyCode.

Also removed some trailing spaces. 

Before:
![Screen Shot 2021-06-09 at 10 44 44 PM](https://user-images.githubusercontent.com/454966/121456646-643c6100-c974-11eb-9f91-37f682653922.png)

After:
![Screen Shot 2021-06-09 at 10 44 15 PM](https://user-images.githubusercontent.com/454966/121456664-6a324200-c974-11eb-9933-981217c98a63.png)


## Does this address a known issue?
I'm not sure if it was known but I was noticing some null data being output and wanted to fix it.

## How should the reviewer approach this PR?
I verified by opening the index.html locally and performing a search. I used Chrome, Firefox and Safari on a Mac.
My steps:
1. Entered `New Hampshire` in the search input and hit the enter key
2. Searched (using the browser search) for "Frogg" (this brewery returns null for the address and website)
3. Verified the data that is returned as !null is displayed

## Anything else?
Cheers! 🍺 